### PR TITLE
ci: Release pre-1.0 versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "go",
-      "bump-minor-pre-major": false,
+      "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false


### PR DESCRIPTION
Keep the version below 1.0.0 to indicate active development with frequent breaking changes.
