### PR TITLE
feat: Separate flags for live UI assets

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,8 @@
 	"name": "Go",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	}
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,11 @@
             "mode": "auto",
             "cwd": "${workspaceFolder}",
             "program": "./cmd/flight-school",
-            "args": ["--debug"],
+            "args": [
+                "--debug",
+                "--static-dir=./static",
+                "--template-dir=./html",
+            ],
             "env": {
                 "FLIGHT_SCHOOL_DSN": "postgres://${env:POSTGRES_USER}:${env:POSTGRES_PASSWORD}@${env:POSTGRES_HOSTNAME}/${env:POSTGRES_DB}"
             }


### PR DESCRIPTION
Add separate flags to enable live loading of templates and static assets instead of coupling them to the `--debug` flag. This makes it possible to get debug logging while still using the embedded assets.

Closes #11
