### PR TITLE
fix: Show correct public ID for task elements

### DIFF
--- a/html/partials/task-elements.html.tmpl
+++ b/html/partials/task-elements.html.tmpl
@@ -2,7 +2,7 @@
   {{ with . }}
   <div class="task-element-list">
     {{ range . }}
-    <p class="text-subtle">PA.I.A.{{ .Type }}{{ .PublicID }}</p>
+    <p class="text-subtle">{{ .FullPublicID }}</p>
     <div class="mb-xs">
       {{ .Content }}
       {{ with .SubElements }}

--- a/internal/models/acs.go
+++ b/internal/models/acs.go
@@ -83,6 +83,8 @@ type TaskElement struct {
 	PublicID int32
 	Content  string
 
+	FullPublicID string
+
 	SubElements []SubElement
 }
 
@@ -261,7 +263,7 @@ func (m *ACSModel) listElementsForTask(ctx context.Context, taskID int32) (map[T
 
 	elementIDs := make([]int32, 0)
 	for _, e := range elements {
-		elementIDs = append(elementIDs, e.ID)
+		elementIDs = append(elementIDs, e.AcsElement.ID)
 	}
 
 	subElements, err := m.listSubElements(ctx, elementIDs)
@@ -271,18 +273,19 @@ func (m *ACSModel) listElementsForTask(ctx context.Context, taskID int32) (map[T
 
 	elementsByType := make(map[TaskElementType][]TaskElement)
 	for _, e := range elements {
-		elementType := taskElementTypeFromModel(e.Type)
+		elementType := taskElementTypeFromModel(e.AcsElement.Type)
 		if _, ok := elementsByType[elementType]; !ok {
 			elementsByType[elementType] = make([]TaskElement, 0, 1)
 		}
 
 		element := TaskElement{
-			ID:          e.ID,
-			TaskID:      e.TaskID,
-			Type:        elementType,
-			PublicID:    e.PublicID,
-			Content:     e.Content,
-			SubElements: subElements[e.ID],
+			ID:           e.AcsElement.ID,
+			TaskID:       e.AcsElement.TaskID,
+			Type:         elementType,
+			PublicID:     e.AcsElement.PublicID,
+			Content:      e.AcsElement.Content,
+			FullPublicID: e.FullPublicID,
+			SubElements:  subElements[e.AcsElement.ID],
 		}
 
 		elementsByType[elementType] = append(

--- a/internal/models/queries/queries.sql
+++ b/internal/models/queries/queries.sql
@@ -143,10 +143,14 @@ WHERE task_id = $1
 ORDER BY "order" ASC;
 
 -- name: ListElementsByTaskID :many
-SELECT *
-FROM acs_elements
-WHERE task_id = $1
-ORDER BY "type", public_id ASC;
+SELECT
+    sqlc.embed(e),
+    (a.acs_id || '.' || a.public_id || '.' || t.public_id || '.' || e.type || e.public_id)::text AS full_public_id
+FROM acs_elements e
+    LEFT JOIN acs_area_tasks t ON e.task_id = t.id
+    LEFT JOIN acs_areas a on t.area_id = a.id
+WHERE e.task_id = $1
+ORDER BY e."type", e.public_id ASC;
 
 -- name: SetElementConfidence :exec
 INSERT INTO element_confidence (element_id, vote)


### PR DESCRIPTION
We were using a placeholder of `PA.I.A` for all task elements that we forgot to remove.

Closes #14
