### PR TITLE
feat: Allow for populating ACS during DB migration

### DIFF
--- a/acs/acs.go
+++ b/acs/acs.go
@@ -1,0 +1,6 @@
+package acs
+
+import "embed"
+
+//go:embed *.json
+var Files embed.FS

--- a/cmd/flight-school/main.go
+++ b/cmd/flight-school/main.go
@@ -1,152 +1,18 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"log/slog"
-	"net/http"
 	"os"
-	"os/signal"
-	"time"
 
-	"github.com/cdriehuys/flight-school/html"
-	"github.com/cdriehuys/flight-school/internal/app"
+	"github.com/cdriehuys/flight-school/acs"
 	"github.com/cdriehuys/flight-school/internal/cli"
 	"github.com/cdriehuys/flight-school/migrations"
-	"github.com/cdriehuys/flight-school/static"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-const addr = ":8000"
-
-func executeCLI(logStream io.Writer, migrationFS fs.FS) error {
-	cmd := &cobra.Command{
-		Use:   "flight-school",
-		Short: "Run the flight-school web server",
-		RunE:  webServerRunner(logStream),
-	}
-
-	cmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
-	viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))
-
-	cmd.PersistentFlags().String("dsn", "", "DSN for connecting to the database ($FLIGHT_SCHOOL_DSN)")
-	viper.BindEnv("dsn", "FLIGHT_SCHOOL_DSN")
-	viper.BindPFlag("dsn", cmd.PersistentFlags().Lookup("dsn"))
-	viper.SetDefault("dsn", "postgres://localhost")
-
-	cmd.Flags().String("static-dir", "", "Use static files from this path instead of the embedded files")
-	viper.BindPFlag("static-dir", cmd.Flags().Lookup("static-dir"))
-
-	cmd.Flags().String("template-dir", "", "Use templates from this path instead of the embedded files")
-	viper.BindPFlag("template-dir", cmd.Flags().Lookup("template-dir"))
-
-	cmd.AddCommand(
-		cli.NewMigrateCmd(migrationFS),
-		cli.NewPopulateACSCmd(logStream),
-	)
-
-	return cmd.Execute()
-}
-
-func webServerRunner(logStream io.Writer) func(*cobra.Command, []string) error {
-	return func(c *cobra.Command, s []string) error {
-		return run(logStream)
-	}
-}
-
-func run(logStream io.Writer) error {
-	debug := viper.GetBool("debug")
-	dsn := viper.GetString("dsn")
-
-	logLevel := slog.LevelInfo
-	if debug {
-		logLevel = slog.LevelDebug
-	}
-
-	logger := slog.New(slog.NewTextHandler(logStream, &slog.HandlerOptions{Level: logLevel}))
-
-	appOpts := app.Options{Debug: debug}
-
-	templateDir := viper.GetString("template-dir")
-
-	var templateFiles fs.FS
-	if templateDir != "" {
-		templateFiles = os.DirFS(templateDir)
-		appOpts.LiveTemplates = true
-		logger.Info("Using live templates", "templateDir", templateDir)
-	} else {
-		templateFiles = html.Files
-	}
-
-	staticDir := viper.GetString("static-dir")
-
-	var staticFiles fs.FS
-	if staticDir != "" {
-		staticFiles = os.DirFS(staticDir)
-		logger.Info("Using live static files", "staticDir", staticDir)
-	} else {
-		staticFiles = static.Files
-	}
-
-	db, err := pgxpool.New(context.Background(), dsn)
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %v", err)
-	}
-
-	defer db.Close()
-
-	app, err := app.New(logger, templateFiles, staticFiles, db, &appOpts)
-	if err != nil {
-		return fmt.Errorf("failed to build app: %v", err)
-	}
-
-	logger.Info("Starting server", "address", addr)
-
-	s := http.Server{
-		Addr:    addr,
-		Handler: app.Routes(),
-	}
-
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-
-	go func() {
-		if err := s.ListenAndServe(); err != nil {
-			if !errors.Is(err, http.ErrServerClosed) {
-				logger.Error("Unexpected server error.", "error", err)
-			}
-		}
-	}()
-
-	<-interrupt
-	signal.Stop(interrupt)
-
-	logger.Info("Received interrupt, shutting down.")
-
-	shutdownContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if err := s.Shutdown(shutdownContext); err != nil {
-		logger.Error("Server did not shut down gracefully.", "error", err)
-	}
-	logger.Info("Web server stopped.")
-
-	logger.Info("Closing database connection.")
-	db.Close()
-	logger.Info("Database connection closed.")
-
-	logger.Info("Shutdown complete.")
-
-	return nil
-}
-
 func main() {
-	if err := executeCLI(os.Stderr, migrations.Files); err != nil {
+	cmd := cli.NewRootCmd(os.Stderr, acs.Files, migrations.Files)
+
+	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -1,57 +1,129 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"io/fs"
-	"log"
+	"log/slog"
+	"os"
 
-	"github.com/jackc/pgx/v5"
+	"github.com/cdriehuys/flight-school/internal/models"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/tern/v2/migrate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func NewMigrateCmd(migrationFS fs.FS) *cobra.Command {
-	return &cobra.Command{
+func newMigrateCmd(logStream io.Writer, acsDocs fs.FS, migrationFS fs.FS) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Migrate the database forwards",
-		RunE:  migrateRunner(migrationFS),
+		RunE:  migrateRunner(logStream, acsDocs, migrationFS),
 	}
+
+	cmd.Flags().String("acs-dir", "", "Use ACS documents from this path instead of the embedded files")
+	viper.BindPFlag("acs-dir", cmd.Flags().Lookup("acs-dir"))
+
+	cmd.Flags().Bool("populate-acs", false, "Populate the database after migrating it")
+	viper.BindPFlag("populate-acs", cmd.Flags().Lookup("populate-acs"))
+
+	return cmd
 }
 
-func migrateRunner(migrationFS fs.FS) func(*cobra.Command, []string) error {
-	return func(c *cobra.Command, s []string) error {
+func migrateRunner(logStream io.Writer, acsDocs fs.FS, migrationFS fs.FS) func(*cobra.Command, []string) error {
+	return func(cli *cobra.Command, s []string) error {
+		logger := createLogger(logStream)
+
 		dsn := viper.GetString("dsn")
-		conn, err := pgx.Connect(c.Context(), dsn)
+		pool, err := pgxpool.New(cli.Context(), dsn)
 		if err != nil {
 			return fmt.Errorf("failed to connect to database: %v", err)
 		}
 
-		defer func() {
-			if err := conn.Close(c.Context()); err != nil {
-				log.Printf("Error closing database connection: %v", err)
+		defer pool.Close()
+
+		err = pool.AcquireFunc(cli.Context(), func(c *pgxpool.Conn) error {
+			migrator, err := migrate.NewMigrator(cli.Context(), c.Conn(), "public.schema_version")
+			if err != nil {
+				return fmt.Errorf("failed to build migrator: %v", err)
 			}
-		}()
 
-		migrator, err := migrate.NewMigrator(c.Context(), conn, "public.schema_version")
+			if err := migrator.LoadMigrations(migrationFS); err != nil {
+				return fmt.Errorf("failed to load migrations: %v", err)
+			}
+
+			migrator.OnStart = func(i int32, name string, direction string, sql string) {
+				logger.Info("Executing migration", "name", name, "direction", direction)
+				logger.Debug("Migration contents", "sql", sql)
+			}
+
+			if err := migrator.Migrate(cli.Context()); err != nil {
+				return fmt.Errorf("failed to run migrations: %v", err)
+			}
+
+			logger.Info("Database migrations completed successfully")
+
+			return nil
+		})
+
 		if err != nil {
-			return fmt.Errorf("failed to build migrator: %v", err)
+			return err
 		}
 
-		if err := migrator.LoadMigrations(migrationFS); err != nil {
-			return fmt.Errorf("failed to load migrations: %v", err)
-		}
+		if viper.GetBool("populate-acs") {
+			acsDir := viper.GetString("acs-dir")
 
-		migrator.OnStart = func(i int32, name string, direction string, sql string) {
-			log.Printf("executing %s %s\n%s\n", name, direction, sql)
-		}
+			var docs fs.FS
+			if acsDir == "" {
+				docs = acsDocs
+			} else {
+				docs = os.DirFS(acsDir)
+			}
 
-		if err := migrator.Migrate(c.Context()); err != nil {
-			return fmt.Errorf("failed to run migrations: %v", err)
+			if err := loadACSDefinitions(cli.Context(), logger, pool, docs); err != nil {
+				return err
+			}
 		}
-
-		log.Println("Database successfully migrated")
 
 		return nil
 	}
+}
+
+func loadACSDefinitions(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, acsDocuments fs.FS) error {
+	model := models.NewACSModel(logger, db)
+
+	documents, err := fs.Glob(acsDocuments, "*.json")
+	if err != nil {
+		return fmt.Errorf("failed to find ACS documents: %v", err)
+	}
+
+	for _, doc := range documents {
+		if err := loadACSDefinition(ctx, logger, model, acsDocuments, doc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func loadACSDefinition(ctx context.Context, logger *slog.Logger, model acsUpdater, files fs.FS, name string) error {
+	file, err := files.Open(name)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %v", name, err)
+	}
+
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.ErrorContext(ctx, "Failed to close ACS document", "document", name)
+		}
+	}()
+
+	if err := populateACSFromJSON(ctx, model, file); err != nil {
+		return err
+	}
+
+	logger.InfoContext(ctx, "Populated ACS definition", "document", name)
+
+	return nil
 }

--- a/internal/cli/populate_acs.go
+++ b/internal/cli/populate_acs.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func NewPopulateACSCmd(logStream io.Writer) *cobra.Command {
+func newPopulateACSCmd(logStream io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "populate-acs definition-file",
 		Short: "Populate the database with a particular ACS",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/cdriehuys/flight-school/html"
+	"github.com/cdriehuys/flight-school/internal/app"
+	"github.com/cdriehuys/flight-school/static"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func NewRootCmd(logStream io.Writer, acsDocs fs.FS, migrationFS fs.FS) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "flight-school",
+		Short: "Run the flight-school web server",
+		RunE:  webServerRunner(logStream),
+	}
+
+	cmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
+	viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))
+
+	cmd.PersistentFlags().String("dsn", "", "DSN for connecting to the database ($FLIGHT_SCHOOL_DSN)")
+	viper.BindEnv("dsn", "FLIGHT_SCHOOL_DSN")
+	viper.BindPFlag("dsn", cmd.PersistentFlags().Lookup("dsn"))
+	viper.SetDefault("dsn", "postgres://localhost")
+
+	cmd.Flags().String("static-dir", "", "Use static files from this path instead of the embedded files")
+	viper.BindPFlag("static-dir", cmd.Flags().Lookup("static-dir"))
+
+	cmd.Flags().String("template-dir", "", "Use templates from this path instead of the embedded files")
+	viper.BindPFlag("template-dir", cmd.Flags().Lookup("template-dir"))
+
+	cmd.AddCommand(
+		newMigrateCmd(logStream, acsDocs, migrationFS),
+		newPopulateACSCmd(logStream),
+	)
+
+	return cmd
+}
+
+func webServerRunner(logStream io.Writer) func(*cobra.Command, []string) error {
+	return func(c *cobra.Command, s []string) error {
+		return run(logStream)
+	}
+}
+
+const addr = ":8000"
+
+func run(logStream io.Writer) error {
+	debug := viper.GetBool("debug")
+	dsn := viper.GetString("dsn")
+
+	logger := createLogger(logStream)
+
+	appOpts := app.Options{Debug: debug}
+
+	templateDir := viper.GetString("template-dir")
+
+	var templateFiles fs.FS
+	if templateDir != "" {
+		templateFiles = os.DirFS(templateDir)
+		appOpts.LiveTemplates = true
+		logger.Info("Using live templates", "templateDir", templateDir)
+	} else {
+		templateFiles = html.Files
+	}
+
+	staticDir := viper.GetString("static-dir")
+
+	var staticFiles fs.FS
+	if staticDir != "" {
+		staticFiles = os.DirFS(staticDir)
+		logger.Info("Using live static files", "staticDir", staticDir)
+	} else {
+		staticFiles = static.Files
+	}
+
+	db, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %v", err)
+	}
+
+	defer db.Close()
+
+	app, err := app.New(logger, templateFiles, staticFiles, db, &appOpts)
+	if err != nil {
+		return fmt.Errorf("failed to build app: %v", err)
+	}
+
+	logger.Info("Starting server", "address", addr)
+
+	s := http.Server{
+		Addr:    addr,
+		Handler: app.Routes(),
+	}
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	go func() {
+		if err := s.ListenAndServe(); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				logger.Error("Unexpected server error.", "error", err)
+			}
+		}
+	}()
+
+	<-interrupt
+	signal.Stop(interrupt)
+
+	logger.Info("Received interrupt, shutting down.")
+
+	shutdownContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := s.Shutdown(shutdownContext); err != nil {
+		logger.Error("Server did not shut down gracefully.", "error", err)
+	}
+	logger.Info("Web server stopped.")
+
+	logger.Info("Closing database connection.")
+	db.Close()
+	logger.Info("Database connection closed.")
+
+	logger.Info("Shutdown complete.")
+
+	return nil
+}


### PR DESCRIPTION
The `--populate-acs` flag of the `migrate` sub-command loads all the ACS documents into the database. This makes deployment much easier.

Closes #12
