### PR TITLE
feat: Keep element in view when voting

### DIFF
--- a/html/partials/task-elements.html.tmpl
+++ b/html/partials/task-elements.html.tmpl
@@ -3,7 +3,7 @@
   <div class="task-element-list">
     {{ range . }}
     <p class="text-subtle">{{ .FullPublicID }}</p>
-    <div class="mb-xs">
+    <div class="mb-xs" id="{{ .FullPublicID }}">
       {{ .Content }}
       {{ with .SubElements }}
       <ol class="sub-elements">

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,6 +36,7 @@ type acsModel interface {
 	GetTaskConfidence(ctx context.Context, taskID int32) (models.Confidence, error)
 	ListAreasByACS(ctx context.Context, acs string) ([]models.AreaOfOperation, error)
 	ListTasksByArea(ctx context.Context, areaID int32) ([]models.TaskSummary, error)
+	GetElementPublicIDByID(ctx context.Context, elementID int32) (string, error)
 	SetElementConfidence(ctx context.Context, elementID int32, confidence models.ConfidenceLevel) error
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -113,7 +113,19 @@ func (a *App) setElementConfidence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("/acs/%s/%s/%s", task.Area.ACS, task.Area.PublicID, task.PublicID), http.StatusSeeOther)
+	elementPublicID, err := a.acsModel.GetElementPublicIDByID(r.Context(), int32(elementID))
+	if err != nil {
+		a.logger.ErrorContext(r.Context(), "Failed to retrieve public ID for element.", "error", err, "elementID", elementID)
+		a.serverError(w, r, err)
+		return
+	}
+
+	http.Redirect(
+		w,
+		r,
+		fmt.Sprintf("/acs/%s/%s/%s#%s", task.Area.ACS, task.Area.PublicID, task.PublicID, elementPublicID),
+		http.StatusSeeOther,
+	)
 }
 
 func getConfidenceFromForm(values url.Values) (models.ConfidenceLevel, error) {

--- a/internal/models/acs.go
+++ b/internal/models/acs.go
@@ -341,6 +341,15 @@ func (m *ACSModel) listSubElements(ctx context.Context, elementIDs []int32) (map
 	return subElementsByElementID, nil
 }
 
+func (m *ACSModel) GetElementPublicIDByID(ctx context.Context, elementID int32) (string, error) {
+	publicID, err := m.q.GetElementPublicIDByID(ctx, elementID)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve public ID of element %d: %v", elementID, err)
+	}
+
+	return publicID, nil
+}
+
 func (m *ACSModel) SetElementConfidence(ctx context.Context, elementID int32, confidence ConfidenceLevel) error {
 	params := queries.SetElementConfidenceParams{
 		ElementID: elementID,

--- a/internal/models/queries/queries.sql
+++ b/internal/models/queries/queries.sql
@@ -142,6 +142,14 @@ FROM task_references
 WHERE task_id = $1
 ORDER BY "order" ASC;
 
+-- name: GetElementPublicIDByID :one
+SELECT
+    (a.acs_id || '.' || a.public_id || '.' || t.public_id || '.' || e.type || e.public_id)::text AS full_public_id
+FROM acs_elements e
+    LEFT JOIN acs_area_tasks t ON e.task_id = t.id
+    LEFT JOIN acs_areas a on t.area_id = a.id
+WHERE e.id = $1;
+
 -- name: ListElementsByTaskID :many
 SELECT
     sqlc.embed(e),


### PR DESCRIPTION
When a vote is recorded for an element, the next page load ensures that element is in view. There can still be a bit of a page jump, but it's better than before.

Closes #33
